### PR TITLE
feat: Implement Phase 1.2 File Discovery & Scanning

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -17,13 +17,20 @@ def load_config() -> Dict[str, Any]:
             "logging" : {
                 "level" : "INFO",
                 "file" : str(CONFIG_DIR/ "dexidoc.log")
-            }
+            },
+            "excludes": ['.*', '__pycache__', 'node_modules', '.git', '.venv'],
+            "extensions": ['.pdf', '.txt', '.docx']
         }
     
     try:
         with open(CONFIG_FILE, "rb") as f:
             config = tomli.load(f)
             config["config_path"] = str(CONFIG_FILE) # Inject path for reference
+            
+            # Set defaults for missing keys
+            config.setdefault("excludes", ['.*', '__pycache__', 'node_modules', '.git', '.venv'])
+            config.setdefault("extensions", ['.pdf', '.txt', '.docx'])
+            
             return config
         
     except Exception as e:

--- a/src/discovery/__init__.py
+++ b/src/discovery/__init__.py
@@ -1,0 +1,3 @@
+from .scanner import FileScanner
+
+__all__ = ["FileScanner"]

--- a/src/discovery/scanner.py
+++ b/src/discovery/scanner.py
@@ -1,0 +1,69 @@
+import os
+import fnmatch
+from pathlib import Path
+from typing import List, Generator, Set
+from ..models import DiscoveredFile
+
+class FileScanner:
+    def __init__(self, base_path: Path, excludes: List[str] = None, extensions: List[str] = None):
+        self.base_path = base_path
+        self.excludes = excludes or []
+        self.extensions = set(ext.lower() for ext in (extensions or []))
+
+    def _is_excluded(self, path: Path) -> bool:
+        """Check if path matches any exclude pattern."""
+        name = path.name
+        rel_path = None
+        try:
+            rel_path = path.relative_to(self.base_path).as_posix()
+        except ValueError:
+            pass
+
+        for pattern in self.excludes:
+            if fnmatch.fnmatch(name, pattern):
+                return True
+            if rel_path and fnmatch.fnmatch(rel_path, pattern):
+                return True
+        return False
+
+    def _is_allowed_extension(self, path: Path) -> bool:
+        """Check if file extension is in allowed list."""
+        if not self.extensions:
+            # If no extensions defined, strict filtering implies matching nothing.
+            return False 
+        return path.suffix.lower() in self.extensions
+
+    def scan(self) -> Generator[DiscoveredFile, None, None]:
+        """Recursive directory scan yielding DiscoveredFile objects."""
+        # Validate base path
+        if not self.base_path.exists():
+            raise FileNotFoundError(f"Base path does not exist: {self.base_path}")
+
+        if not self.base_path.is_dir():
+            raise NotADirectoryError(f"Base path is not a directory: {self.base_path}")
+
+        # Use os.walk for controlled traversal (pruning directories)
+        for root, dirs, files in os.walk(self.base_path):
+            root_path = Path(root)
+            
+            # Prune directories based on exclusion rules
+            # We modify dirs in-place to stop os.walk from entering them
+            dirs[:] = [d for d in dirs if not self._is_excluded(root_path / d)]
+            
+            for file in files:
+                file_path = root_path / file
+                
+                if self._is_excluded(file_path):
+                    continue
+                
+                if self._is_allowed_extension(file_path):
+                    try:
+                        size = file_path.stat().st_size
+                        yield DiscoveredFile(
+                            path=file_path,
+                            file_type=file_path.suffix.lower(),
+                            size=size
+                        )
+                    except OSError:
+                        # Skip files we can't stat
+                        continue

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,17 +1,17 @@
 import logging
 import sys
 from pathlib import Path
-from typing import any, Dict
+from typing import Any, Dict
 from .config import ensure_config_dir
 
-def setup_logging(config:Dict [str, any]) -> logging.Logger:
+def setup_logging(config: Dict[str, Any]) -> logging.Logger:
     """
     Setup logging to file and stdout
     """
     ensure_config_dir()
 
     log_file = config.get("logging", {}).get("file", str(Path.home()/ ".dexidoc"/ "dexidoc.log"))
-    log_level = config.get("logging {}").get("level","Info").upper()
+    log_level = config.get("logging", {}).get("level", "Info").upper()
 
     logger = logging.getLogger("dexidoc")
     logger.setLevel(log_level)

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+@dataclass
+class DiscoveredFile:
+    path: Path
+    file_type: str
+    size: int

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,81 @@
+import os
+import pytest
+import shutil
+from pathlib import Path
+from src.discovery import FileScanner
+
+@pytest.fixture
+def scanner_test_dir(tmp_path):
+    """Create a temporary directory structure for testing."""
+    # Structure:
+    # root/
+    #   doc1.txt
+    #   script.py (excluded ext)
+    #   subdir/
+    #     doc2.pdf
+    #     ignore.txt (excluded name)
+    #   ignored_folder/
+    #     doc3.docx
+    #   nested/
+    #     deep/
+    #       skip_me.txt (excluded relative)
+    
+    root = tmp_path / "scan_root"
+    root.mkdir()
+    
+    (root / "doc1.txt").touch()
+    (root / "script.py").touch()
+    
+    subdir = root / "subdir"
+    subdir.mkdir()
+    (subdir / "doc2.pdf").touch()
+    (subdir / "ignore.txt").touch()
+    
+    ignored = root / "ignored_folder"
+    ignored.mkdir()
+    (ignored / "doc3.docx").touch()
+    
+    nested = root / "nested" / "deep"
+    nested.mkdir(parents=True)
+    (nested / "skip_me.txt").touch()
+    
+    return root
+
+def test_scanner_basic(scanner_test_dir):
+    extensions = [".txt", ".pdf"]
+    excludes = []
+    scanner = FileScanner(scanner_test_dir, excludes, extensions)
+    
+    results = list(scanner.scan())
+    files = {f.path.name for f in results}
+    
+    assert "doc1.txt" in files
+    assert "doc2.pdf" in files
+    assert "script.py" not in files # Wrong extension
+
+def test_scanner_exclusions(scanner_test_dir):
+    extensions = [".txt", ".pdf", ".docx"]
+    # Exclude by name and by relative path
+    excludes = ["ignored_folder", "ignore.txt", "nested/deep/skip_me.txt"]
+    scanner = FileScanner(scanner_test_dir, excludes, extensions)
+    
+    results = list(scanner.scan())
+    paths = {str(f.path.relative_to(scanner_test_dir)).replace(os.sep, "/") for f in results}
+    
+    assert "doc1.txt" in paths
+    assert "subdir/doc2.pdf" in paths
+    
+    # Excluded by dir name
+    assert "ignored_folder/doc3.docx" not in paths
+    # Excluded by file name
+    assert "subdir/ignore.txt" not in paths
+    # Excluded by relative path
+    assert "nested/deep/skip_me.txt" not in paths
+
+def test_scanner_invalid_path():
+    with pytest.raises(FileNotFoundError):
+        list(FileScanner(Path("non_existent_path")).scan())
+        
+    with pytest.raises(NotADirectoryError):
+        # Point to a file, not a dir
+        list(FileScanner(Path(__file__)).scan())


### PR DESCRIPTION
## Description 

This PR adds the core file discovery logic for the scan command. It introduces a FileScanner that recursively scans directories, applies exclusions, and filters files by extension.

##  Changes Made 

-> Implemented FileScanner using os.walk for recursive directory traversal
-> Added support for excluding files and relative paths (e.g. .git, __pycache__)
->Added case-insensitive file extension filtering
->Validated base path before scanning
->Introduced DiscoveredFile dataclass to represent discovered files
->Added default excludes and extensions to configuration
->Added unit tests covering discovery, exclusions, invalid paths, and extensions

## Verification

All tests pass with pytest

Fixes #3 
