### PR TITLE
fix: add missing discovery.py module and fix logger.py syntax errors

### DIFF
--- a/src/discovery.py
+++ b/src/discovery.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Iterator, List
+
+@dataclass
+class FileInfo:
+    path: Path
+    size: int
+
+class FileScanner:
+    def __init__(self, base_path: Path, excludes: List[str] = None, extensions: List[str] = None):
+        self.base_path = base_path
+        self.excludes = excludes or []
+        self.extensions = extensions or ['.pdf', '.txt', '.md', '.doc', '.docx']
+    
+    def scan(self) -> Iterator[FileInfo]:
+        for item in self.base_path.rglob('*'):
+            if not item.is_file():
+                continue
+            
+            if any(exclude in str(item) for exclude in self.excludes):
+                continue
+            
+            if self.extensions and item.suffix.lower() not in self.extensions:
+                continue
+            
+            yield FileInfo(path=item, size=item.stat().st_size)

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,17 +1,17 @@
 import logging
 import sys
 from pathlib import Path
-from typing import any, Dict
+from typing import Any, Dict
 from .config import ensure_config_dir
 
-def setup_logging(config:Dict [str, any]) -> logging.Logger:
+def setup_logging(config: Dict[str, Any]) -> logging.Logger:
     """
     Setup logging to file and stdout
     """
     ensure_config_dir()
 
-    log_file = config.get("logging", {}).get("file", str(Path.home()/ ".dexidoc"/ "dexidoc.log"))
-    log_level = config.get("logging {}").get("level","Info").upper()
+    log_file = config.get("logging", {}).get("file", str(Path.home() / ".dexidoc" / "dexidoc.log"))
+    log_level = config.get("logging", {}).get("level", "INFO").upper()
 
     logger = logging.getLogger("dexidoc")
     logger.setLevel(log_level)
@@ -25,6 +25,5 @@ def setup_logging(config:Dict [str, any]) -> logging.Logger:
     stdout_handler = logging.StreamHandler(sys.stdout)
     stdout_handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
     logger.addHandler(stdout_handler)
-
 
     return logger


### PR DESCRIPTION
## Description
This PR fixes critical bugs that prevented the application from running:
1. Adds the missing `src/discovery.py` module
2. Fixes syntax errors in `src/logger.py`
Fixes #5 

## Problem
The application was importing `FileScanner` from a non-existent `discovery` module, causing `ModuleNotFoundError` on startup. Additionally, `logger.py` had several syntax errors.

## Changes Made

### Added `src/discovery.py`
- Created `FileInfo` dataclass to store file metadata (path, size)
- Implemented `FileScanner` class with:
  - Constructor accepting `base_path`, `excludes`, and `extensions` parameters
  - `scan()` method that recursively finds files matching criteria
  - Support for filtering by file extensions and exclude patterns

### Fixed `src/logger.py`
- Fixed import: `any` → `Any` (line 4)
- Fixed type hint spacing: `Dict [str, any]` → `Dict[str, Any]` (line 7)
- Fixed malformed dict access: `config.get("logging {}")` → `config.get("logging", {})` (line 12)
- Fixed capitalization: `"Info"` → `"INFO"` (line 12)

## Testing
Verified that the application now runs successfully:
```bash
# Status command works
python -m src.main status
# Output: Dexidoc CLI is running!

# Scan command works
python -m src.main scan .
# Output: Found 1 files (README.md)
```

## Impact
- ✅ Application can now be run from source
- ✅ All commands (`status`, `scan`) work correctly
- ✅ Unblocks contributors from testing the project

## Checklist
- [x] Code follows project style
- [x] Changes tested locally
- [x] No breaking changes
- [x] Minimal implementation (Phase 1 scope)
